### PR TITLE
PP-1521: Turn on snmp so metrics can be scraped

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -52,6 +52,7 @@ default['squid']['logformats'] = {}
 default['squid']['access_log_option'] = 'squid'
 
 default['squid']['enable_ldap']       = false
+default['squid']['enable_snmp_local'] = false
 default['squid']['ldap_host']         = nil   # 'ldap.here.com'
 default['squid']['ldap_basedn']       = nil   # 'dc=here,dc=com'
 default['squid']['ldap_binddn']       = nil   # 'uid=some-user,ou=People,dc=here,dc=com'

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -5,11 +5,17 @@ module Opscode
       def squid_version
         case node['platform_family']
         when 'debian'
-          return '3.1' if node['platform_version'].to_i == 7
-          return '3.1' if node['platform_version'].to_i == 12
-          return '3.1' if node['platform_version'].to_i == 14
-          return '3.4' if node['platform_version'].to_i == 8
-          return '3.5' if node['platform_version'].to_i == 16
+          if node['platform'] == 'ubuntu'
+            return '3.1' if node['platform_version'] == '12.04'
+            return '3.3' if node['platform_version'] == '14.04'
+            return '3.5' if node['platform_version'] == '16.04'
+          else
+            return '3.1' if node['platform_version'].to_i == 7
+            return '3.1' if node['platform_version'].to_i == 12
+            return '3.1' if node['platform_version'].to_i == 14
+            return '3.4' if node['platform_version'].to_i == 8
+            return '3.5' if node['platform_version'].to_i == 16
+          end
         when 'rhel'
           return '2.6' if node['platform_version'].to_i == 5
           return '3.1' if node['platform_version'].to_i == 6

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license          'Apache 2.0'
 description      'Installs/configures squid as a simple caching proxy'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.0.0'
+version          '2.0.1'
 
 %w(debian ubuntu centos fedora redhat scientific suse amazon smartos freebsd).each do |os|
   supports os

--- a/templates/default/squid.conf.erb
+++ b/templates/default/squid.conf.erb
@@ -12,6 +12,12 @@ auth_param basic credentialsttl <%= node['squid']['ldap_authcredentialsttl'] %>
     <%= node['squid']['cache_peer'] %>
 <% end %>
 
+<% if node['squid']['enable_snmp_local'] %>
+acl snmppublic snmp_community public
+snmp_access allow snmppublic localhost
+snmp_access deny all
+snmp_port 3401   
+<% end %>
 <%= "acl all src" if @version.to_i < 3 %>
 <%= "acl manager proto cache_object" if @version.to_f < 3.2 %>
 <%= "acl localhost src 127.0.0.1/32" if @version.to_f < 3.2 %>


### PR DESCRIPTION


### Description

It only allows localhost to access it. Which is
the probably the most common use case (with collectd/
telegraf).

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
