### PR TITLE
PP-1931 add arbitrary http access statements

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,6 +32,7 @@ default['squid']['package'] = 'squid'
 default['squid']['config_dir'] = '/etc/squid'
 default['squid']['config_include_dir'] = nil   # '/etc/squid/conf.d'
 default['squid']['config_file'] = '/etc/squid/squid.conf'
+default['squid']['extra_http_access_lines'] = []
 default['squid']['log_dir'] = '/var/log/squid'
 default['squid']['log_module'] = nil # e.g. syslog, stdio, or none (nil != none)
 default['squid']['cache_dir'] = '/var/spool/squid'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license          'Apache-2.0'
 description      'Installs/configures squid as a simple caching proxy'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.2.0'
+version          '3.2.1'
 
 recipe 'squid::default', 'Installs and configures Squid.'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -93,6 +93,8 @@ file "#{node['squid']['config_dir']}/msntauth.conf" do
   action :delete
 end
 
+extra_http_access_lines = node['squid']['extra_http_access_lines'].select { |x| x.match(/^http_access /) }
+
 # squid config
 template node['squid']['config_file'] do
   source 'squid.conf.erb'
@@ -104,6 +106,7 @@ template node['squid']['config_file'] do
         host_acl: host_acl,
         url_acl: url_acl,
         acls: acls,
+        extra_http_access_lines: extra_http_access_lines,
         directives: node['squid']['directives'],
         localnets: node['squid']['localnets'],
         log_module: node['squid']['log_module'],

--- a/templates/default/squid.conf.erb
+++ b/templates/default/squid.conf.erb
@@ -52,6 +52,10 @@ acl <%= url[0] %> <%= url[1] %> <%= url[2] %>
 http_access <%= acl[0] %> <%= acl[1] %> <%= acl[2] %>
 <% end %>
 
+<% @extra_http_access_lines.each do |line| %>
+<%= line %>
+<% end %>
+
 http_access allow manager localhost
 http_access deny manager
 http_access allow purge localhost


### PR DESCRIPTION
### Description

Speculative PR for feedback.

We need to tighten up our ACLs to restrict on more conditions than the existing squid cookbook supports, and additionally it'd be useful to override ACLs using node attributes.

This is my (so far untested) stab at that. I'm going to be in meetings for a while, so I figure I'd open this PR to show my workings. Comments welcome.